### PR TITLE
chore: release 1.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.4.0-SNAPSHOT
+version=1.3.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.0-SNAPSHOT
+version=1.4.0-SNAPSHOT

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,8 +4,8 @@ metadata:
   name: PluginCommentWidget
 spec:
   enabled: true
-  version: "1.2.0"
-  requires: ">=2.2.0"
+  version: "1.3.0"
+  requires: ">=2.3.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
发布 1.3.0。

注意，此版本因为获取用户数据接口的结构改动，会是一个破坏性更新：

1. Halo 2.3.0 以下的版本只能用 1.2.0 以下版本的插件。
2. Halo 2.3.0 及以上的版本需要使用 1.3.0 以上版本的插件。

```release-note
None
```