### PR TITLE
refactor: use visibleReplyCount instead of replyCount to show reply count

### DIFF
--- a/packages/comment-widget/src/components/CommentItem.vue
+++ b/packages/comment-widget/src/components/CommentItem.vue
@@ -198,7 +198,7 @@ const handleUpvote = async () => {
           >
             <MdiCommentQuoteOutline v-if="!showReplies" class="h-3.5 w-3.5" />
             <MdiCommentQuote v-else class="h-3.5 w-3.5" />
-            <span> {{ comment?.status?.replyCount || 0 }} </span>
+            <span> {{ comment?.status?.visibleReplyCount || 0 }} </span>
           </div>
           <span class="text-gray-600">·</span>
           <span


### PR DESCRIPTION
使用 visibleReplyCount 字段来代替 replyCount 字段来显示回复数量，修复未审核过的回复包含在了评论的回复数量中的问题。

/kind improvement

see https://github.com/halo-dev/halo/pull/3578

```release-note
修复未审核过的回复包含在了评论的回复数量中的问题
```