### PR TITLE
chore: add app id annotation

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -2,6 +2,10 @@ apiVersion: plugin.halo.run/v1alpha1
 kind: Plugin
 metadata:
   name: PluginCommentWidget
+  annotations:
+    # Add supports for Halo App Store
+    # https://halo.run/store/apps/app-YXyaD
+    "store.halo.run/app-id": "app-YXyaD"
 spec:
   enabled: true
   requires: ">=2.6.0"


### PR DESCRIPTION
添加应用市场 ID 的 annotation，方便在首次初始化 Halo 之后可以在应用市场检测后续的更新。

/kind improvement

```release-note
添加应用市场的 App ID 字段，使其可以在内置的应用市场检测新版本。
```