### PR TITLE
fix: can not display current size option

### DIFF
--- a/packages/comment-widget/src/components/Comment.vue
+++ b/packages/comment-widget/src/components/Comment.vue
@@ -187,6 +187,7 @@ provide<Ref<string[]>>("upvotedReplies", upvotedReplies);
         :page="comments.page"
         :size="comments.size"
         :total="comments.total"
+        :size-options="[20, 30, 50, 100]"
         class="bg-transparent"
         @change="handlePaginationChange"
       />


### PR DESCRIPTION
修复不显示当前分页条数的问题。

before:

<img width="409" alt="image" src="https://github.com/halo-sigs/plugin-comment-widget/assets/21301288/e8c9243f-f881-48cd-8588-81b9a75bc0d0">

after:

<img width="473" alt="image" src="https://github.com/halo-sigs/plugin-comment-widget/assets/21301288/4598e738-447f-47f4-a4cb-67eec8a576c6">

/kind bug

```release-note
修复不显示当前分页条数的问题。
```