### PR TITLE
Fix widget CSS output filename

### DIFF
--- a/packages/widget/rslib.config.mjs
+++ b/packages/widget/rslib.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
     minify: true,
     cleanDistPath: true,
     filename: {
+      css: 'index.css',
       js: (pathData) => {
         if (pathData.chunk.name === 'index') {
           return 'comment-widget.js';


### PR DESCRIPTION
## What changed

- Configure Rslib to emit the widget stylesheet as `index.css`.
- Keep the generated CSS filename aligned with the path used by `CommentWidgetHeadProcessor`.

## Why

After the Rslib dependency update, the widget build emitted the stylesheet with a generated name such as `59.css`, while `CommentWidgetHeadProcessor` continued to request `index.css`. As a result, the widget stylesheet could not be loaded.

## Validation

- `pnpm --filter ./packages/widget build`
- `pnpm exec biome check packages/widget/rslib.config.mjs`
- `./gradlew build`
